### PR TITLE
Add optional battery emulation

### DIFF
--- a/BasiliskII/src/main.cpp
+++ b/BasiliskII/src/main.cpp
@@ -187,10 +187,19 @@ bool InitAll(const char *vmdir)
 #endif
 
 	// Install ROM patches
-	if (!PatchROM()) {
-		ErrorAlert(STR_UNSUPPORTED_ROM_TYPE_ERR);
-		return false;
-	}
+        if (!PatchROM()) {
+                ErrorAlert(STR_UNSUPPORTED_ROM_TYPE_ERR);
+                return false;
+        }
+
+        // Fake battery information if requested
+        if (PrefsFindBool("emulatebattery")) {
+                // Pretend a fully charged battery is present
+                WriteMacInt8(0x08ae, 0);       // battery flags
+                WriteMacInt8(0x08af, 100);     // battery level
+                XPRAM[0x98] = 100;             // store last known level
+                XPRAM[0x99] = 0;               // flags
+        }
 
 #if ENABLE_MON
 	// Initialize mon

--- a/BasiliskII/src/prefs_items.cpp
+++ b/BasiliskII/src/prefs_items.cpp
@@ -66,9 +66,10 @@ prefs_desc common_prefs_items[] = {
 	{"jitcachesize", TYPE_INT32, false,  "translation cache size in KB"},
 	{"jitlazyflush", TYPE_BOOLEAN, false, "enable lazy invalidation of translation cache"},
 	{"jitinline", TYPE_BOOLEAN, false,   "enable translation through constant jumps"},
-	{"jitblacklist", TYPE_STRING, false, "blacklist opcodes from translation"},
-	{"keyboardtype", TYPE_INT32, false, "hardware keyboard type"},
-	{NULL, TYPE_END, false, NULL} // End of list
+        {"jitblacklist", TYPE_STRING, false, "blacklist opcodes from translation"},
+       {"emulatebattery", TYPE_BOOLEAN, false, "fake PowerBook battery status"},
+        {"keyboardtype", TYPE_INT32, false, "hardware keyboard type"},
+        {NULL, TYPE_END, false, NULL} // End of list
 };
 
 
@@ -100,11 +101,13 @@ void AddPrefsDefaults(void)
 	PrefsAddBool("jitfpu", true);
 	PrefsAddBool("jitdebug", false);
 	PrefsAddInt32("jitcachesize", 8192);
-	PrefsAddBool("jitlazyflush", true);
-	PrefsAddBool("jitinline", true);
+        PrefsAddBool("jitlazyflush", true);
+        PrefsAddBool("jitinline", true);
 #else
-	PrefsAddBool("jit", false);
+        PrefsAddBool("jit", false);
 #endif
+
+    PrefsAddBool("emulatebattery", false);
 
     PrefsAddInt32("keyboardtype", 5);
 }


### PR DESCRIPTION
## Summary
- add `emulatebattery` preference
- allow startup code to fake battery information in PRAM/low memory

## Testing
- `./autogen.sh` *(fails: missing autoconf)*

------
https://chatgpt.com/codex/tasks/task_e_685a20ee80a48326995cf0c35c988dda